### PR TITLE
Primary mixin

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -2,6 +2,16 @@
 
 ### Migrating from v2 to v3
 
+The following CSS classes have been renamed:
+- `o-visual-effects-shadow` is now `o-visual-effects-shadow-low`
+- `o-visual-effects-shadow--ultralow` is now `o-visual-effects-shadow-ultralow`
+- `o-visual-effects-shadow--mid` is now `o-visual-effects-shadow-mid`
+- `o-visual-effects-shadow--high` is now `o-visual-effects-shadow-high`
+
+The following Sass variables have been renamed:
+- `$o-visual-effects-transition-slide` is now `$o-visual-effects-timing-slide`
+- `$o-visual-effects-transition-expand` is now `$o-visual-effects-timing-expand`
+- `$o-visual-effects-transition-fade` is now `$o-visual-effects-timing-fade`
 
 ### Migrating from v1 to v2
 

--- a/README.md
+++ b/README.md
@@ -2,34 +2,70 @@
 
 This [Origami](http://origami.ft.com/) component provides CSS visual effects via a set of Sass variables and mixins.
 
-- [Usage](#usage)
-	- [Markup](#markup)
-	- [Sass](#sass)
+- [Markup](#markup)
+- [Sass](#sass)
 - [Migration Guide](#migration-guide)
 - [Contact](#contact)
 - [Licence](#licence)
 
+## Markup
 
-## Usage
-
-### Markup
-
-When using the build service or importing the module with [silent mode](http://origami.ft.com/docs/syntax/scss/#silent-styles) set to false, o-visual-effects provides helper classes to access the different levels of box shadow settings. The main class available is: `.o-visual-effects-shadow` which outputs a _low_ shadow. To access any other level of shadow, you should use the modifier for that level, for example: `.o-visual-effects-shadow--high`.
+`o-visual-effects` provides helper classes to style with different levels of box shadow:
+- `.o-visual-effects-shadow-ultralow`
+- `.o-visual-effects-shadow-low`
+- `.o-visual-effects-shadow-mid`
+- `.o-visual-effects-shadow-high`
 
 ```html
-<div class="box o-visual-effects-shadow--high">Box content</div>
+<div class="o-visual-effects-shadow-high">Box content</div>
 ```
 
-### Sass
+`o-visual-effects` also provides [timing functions](https://developer.mozilla.org/en-US/docs/Web/CSS/transition-timing-function) for slide, expand, or fade animations and transitions as [CSS custom properties](#css-custom-properties) (CSS Variables). Sass users may use [Sass variables](#sass) to apply these timing functions instead.
 
-As with all Origami components, o-visual-effects has a [silent mode](http://origami.ft.com/docs/syntax/scss/#silent-styles). To use its compiled CSS (rather than using its mixins with your own Sass) set `$o-visual-effects-is-silent : false;` in your Sass before you import the o-visual-effects Sass.
+## CSS Custom Properties
 
-```sass
-$o-visual-effects-is-silent: false;
-@import 'o-visual-effects/main';
+Build Service users may use CSS Custom Properties (CSS Variables) to apply consistent [timing functions](https://developer.mozilla.org/en-US/docs/Web/CSS/transition-timing-function) within custom CSS. The variables avalible are:
+
+- `--o-visual-effects-timing-slide`
+- `--o-visual-effects-timing-expand`
+- `--o-visual-effects-timing-fade`
+
+E.g.
+```css
+.transition--slide {
+	transition: all 0.5s var(--o-visual-effects-timing-slide);
+}
+
+.transition--expand {
+	transition: all 0.5s var(--o-visual-effects-timing-expand);
+}
+
+.transition--fade {
+	transition: all 0.5s var(--o-visual-effects-timing-fade);
+}
 ```
 
-#### Shadows mixin
+Sass users should use [Sass variables](#sass) instead for improved browser support.
+
+## Sass
+
+To include all `o-visual-effects` css call the `oVisualEffects` mixin. This will include box shadow styles and CSS custom properties for transition [timing functions](https://developer.mozilla.org/en-US/docs/Web/CSS/transition-timing-function).
+
+```scss
+@include oVisualEffects();
+```
+
+`o-visual-effects` may also be output granularly. For example ommit the CSS custom properties if you are using Sass variables such as `$o-visual-effects-timing-slide` instead:
+
+```scss
+@mixin oVisualEffects($opts: (
+	'shadows': ('ultralow', 'low', 'mid', 'high')
+));
+```
+
+If you are not using `o-visual-effects` CSS, and instead are using other Sass mixins or variables directly there is no need to call `oVisualEffects`.
+
+### Shadows mixin
 
 The `oVisualEffectsShadowsElevation` mixin is used to add a consistent shadow to your element. There are 4 levels of shadow available: `ultralow`, `low` (default), `mid`, and `high`.
 
@@ -57,15 +93,15 @@ Example:
 
 ```sass
 .transition--slide {
-	transition: all 0.5s $o-visual-effects-transition-slide;
+	transition: all 0.5s $o-visual-effects-timing-slide;
 }
 
 .transition--expand {
-	transition: all 0.5s $o-visual-effects-transition-expand;
+	transition: all 0.5s $o-visual-effects-timing-expand;
 }
 
 .transition--fade {
-	transition: all 0.5s $o-visual-effects-transition-fade;
+	transition: all 0.5s $o-visual-effects-timing-fade;
 }
 ```
 

--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -1,5 +1,7 @@
 @import '../../main';
 
+@include oVisualEffects();
+
 $card-size: 160px;
 
 .demo-canvas {
@@ -15,43 +17,23 @@ $card-size: 160px;
 	left: 10px;
 }
 
+.shadows-demo div,
 .demo-card {
 	display: inline-block;
+	display: inline-flex; // sass-lint:disable-line no-duplicate-properties fallback for no flex support
 	background: white;
 	width: $card-size;
 	height: $card-size;
 	margin: 20px;
-}
-
-.demo-card-label {
-	display: table-cell;
-	width: $card-size;
-	height: $card-size;
-	text-align: center;
-	vertical-align: middle;
-}
-
-// shadows
-.demo-shadows-elevation--ultralow {
-	@include oVisualEffectsShadowsElevation('ultralow');
-}
-
-.demo-shadows-elevation--low {
-	@include oVisualEffectsShadowsElevation('low');
-}
-
-.demo-shadows-elevation--mid {
-	@include oVisualEffectsShadowsElevation('mid');
-}
-
-.demo-shadows-elevation--high {
-	@include oVisualEffectsShadowsElevation('high');
+	text-align: center; //fallback for no flex support
+	justify-content: center;
+	align-items: center;
 }
 
 // transitions
 .demo-transitions--slide {
 	background: slateblue;
-	transition: all 0.5s $o-visual-effects-transition-slide;
+	transition: all 0.5s $o-visual-effects-timing-slide;
 
 	.demo-off & {
 		transform: translateY(0);
@@ -65,7 +47,7 @@ $card-size: 160px;
 .demo-transitions--expand {
 	overflow: hidden;
 	background: darkseagreen;
-	transition: all 0.5s $o-visual-effects-transition-expand;
+	transition: all 0.5s $o-visual-effects-timing-expand;
 
 	.demo-off & {
 		max-height: $card-size;
@@ -78,7 +60,7 @@ $card-size: 160px;
 
 .demo-transitions--fade {
 	background: tomato;
-	transition: all 0.5s $o-visual-effects-transition-fade;
+	transition: all 0.5s $o-visual-effects-timing-fade;
 
 	.demo-off & {
 		opacity: 1;

--- a/demos/src/shadows.mustache
+++ b/demos/src/shadows.mustache
@@ -1,12 +1,8 @@
-<div class="demo-card demo-shadows-elevation demo-shadows-elevation--ultralow">
-	<div class="demo-card-label">ultralow</div>
-</div>
-<div class="demo-card demo-shadows-elevation demo-shadows-elevation--low">
-	<div class="demo-card-label">low</div>
-</div>
-<div class="demo-card demo-shadows-elevation demo-shadows-elevation--mid">
-	<div class="demo-card-label">mid</div>
-</div>
-<div class="demo-card demo-shadows-elevation demo-shadows-elevation--high">
-	<div class="demo-card-label">high</div>
-</div>
+<div class="o-visual-effects-shadow-ultralow">ultralow</div>
+
+<div class="o-visual-effects-shadow-low">low</div>
+
+<div class="o-visual-effects-shadow-mid">mid</div>
+
+<div class="o-visual-effects-shadow-high">high</div>
+

--- a/main.scss
+++ b/main.scss
@@ -4,23 +4,65 @@
 @import 'src/scss/shadows';
 @import 'src/scss/variables';
 
-@if $o-visual-effects-is-silent == false {
-	.o-visual-effects-shadow {
-		@include oVisualEffectsShadowsElevation;
+/// Outputs styles for visual effects.
+/// @param {list} $opts [('shadows': ('ultralow', 'low', 'mid', 'high'), 'timing-custom-properties': true)] - A map of which visual effects to include.
+/// @example Output all o-visual-effect styles.
+///     @include oVisualEffects();
+/// @example Output only mid shadow styles from o-visual-effect.
+///     @include oVisualEffects($opts: ('shadows': ('mid')))
+/// @example Output only timing css custom properties from o-visual-effect.
+///     @include oVisualEffects($opts: ('timing-custom-properties': true))
+/// @access public
+@mixin oVisualEffects($opts: (
+	'shadows': ('ultralow', 'low', 'mid', 'high'),
+	'timing-custom-properties': true
+)) {
+	// Shadows.
+	$shadows: map-get($opts, 'shadows');
+	$ultralow: index($shadows, 'ultralow');
+	$low: index($shadows, 'low');
+	$mid: index($shadows, 'mid');
+	$high: index($shadows, 'high');
+	// Custom properties for timing functions.
+	$timing: map-get($opts, 'timing-custom-properties');
 
-		&--ultralow {
-			@include oVisualEffectsShadowsElevation('ultralow');
-		}
-
-		&--mid {
-			@include oVisualEffectsShadowsElevation('mid');
-		}
-
-		&--high {
-			@include oVisualEffectsShadowsElevation('high');
+	@if($timing) {
+		:root {
+			--o-visual-effects-timing-slide: #{$o-visual-effects-timing-slide};
+			--o-visual-effects-timing-expand: #{$o-visual-effects-timing-expand};
+			--o-visual-effects-timing-fade: #{$o-visual-effects-timing-fade};
 		}
 	}
 
+	@if($ultralow) {
+		.o-visual-effects-shadow-ultralow {
+			@include oVisualEffectsShadowsElevation('ultralow');
+		}
+	}
+
+	@if($low) {
+		.o-visual-effects-shadow-low {
+			@include oVisualEffectsShadowsElevation('low');
+		}
+	}
+
+
+	@if($mid) {
+		.o-visual-effects-shadow-mid {
+			@include oVisualEffectsShadowsElevation('mid');
+		}
+	}
+
+	@if($high) {
+		.o-visual-effects-shadow-high {
+			@include oVisualEffectsShadowsElevation('high');
+		}
+	}
+}
+
+@if $o-visual-effects-silent == false {
+	@include oVisualEffects();
+
 	// Don't output twice
-	$o-visual-effects-is-silent: true !global;
+	$o-visual-effects-silent: true !global;
 }

--- a/origami.json
+++ b/origami.json
@@ -21,6 +21,7 @@
 		{
 			"title": "Shadows",
 			"name": "shadows",
+			"documentClasses": "shadows-demo",
 			"template": "demos/src/shadows.mustache",
 			"hidden": false,
 			"description": ""
@@ -28,6 +29,7 @@
 		{
 			"title": "Transitions",
 			"name": "transitions",
+			"documentClasses": "transitions-demo",
 			"template": "demos/src/transitions.mustache",
 			"hidden": false,
 			"description": ""

--- a/src/scss/_shadows.scss
+++ b/src/scss/_shadows.scss
@@ -1,8 +1,3 @@
-////
-/// @group o-visual-effects shadows
-/// @link http://registry.origami.ft.com/components/o-visual-effects
-////
-
 /// Elevation
 /// @param {String} $elevation - 'ultra', 'low', 'mid' or 'high'
 /// @param {Color} $color

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -3,13 +3,13 @@
 /// @link http://registry.origami.ft.com/components/o-visual-effects
 ////
 
-$o-visual-effects-is-silent: true !default;
+$o-visual-effects-silent: true !default;
 
 /// Timing function for elements that slide in and out
-$o-visual-effects-transition-slide: cubic-bezier(1, 0, 0.5, 1.275);
+$o-visual-effects-timing-slide: cubic-bezier(1, 0, 0.5, 1.275) !default;
 
 /// Timing function for elements that expand and contract
-$o-visual-effects-transition-expand: cubic-bezier(0.215, 0.61, 0.355, 1);
+$o-visual-effects-timing-expand: cubic-bezier(0.215, 0.61, 0.355, 1) !default;
 
 /// Timing function for elements that fade in and out
-$o-visual-effects-transition-fade: cubic-bezier(0.165, 0.84, 0.44, 1);
+$o-visual-effects-timing-fade: cubic-bezier(0.165, 0.84, 0.44, 1) !default;

--- a/test/scss/_mixins.test.scss
+++ b/test/scss/_mixins.test.scss
@@ -1,0 +1,37 @@
+@include test-module('oVisualEffects') {
+    @include test('Outputs timing css custom properties and shadow classes by default') {
+        // css custom properties for timing functions by default
+        @include assert {
+            @include output($selector: false) {
+                @include oVisualEffects();
+            }
+            @include contains($selector: false) {
+                :root {
+                    --o-visual-effects-timing-slide: cubic-bezier(1, 0, 0.5, 1.275);
+                    --o-visual-effects-timing-expand: cubic-bezier(0.215, 0.61, 0.355, 1);
+                    --o-visual-effects-timing-fade: cubic-bezier(0.165, 0.84, 0.44, 1);
+                }
+            }
+        }
+        // box shadow styles by default
+        @include assert {
+            @include output($selector: false) {
+                @include oVisualEffects();
+            }
+            @include contains($selector: false) {
+                .o-visual-effects-shadow-low {
+                    box-shadow: 0 1px 2px rgba(77, 72, 69, 0.25), 0 4px 6px rgba(77, 72, 69, 0.1);
+                }
+            }
+        }
+    }
+    @include test('Outputs nothing with an empty options map') {
+        @include assert {
+            @include output() {
+                @include oVisualEffects($opts: ());
+            }
+            @include expect() {
+            }
+        }
+    }
+}

--- a/test/scss/index.test.scss
+++ b/test/scss/index.test.scss
@@ -1,0 +1,5 @@
+@import 'true';
+
+@import '../../main';
+
+@import 'mixins.test';


### PR DESCRIPTION
Add primary mixin.
Plus:
- Renames shadow class names (they may be used standalone rather
than as modifiers).
- Rename transition Sass variables to reference they are timing
functions.
- Add CSS custom properties so build service users may use the
timing functions o-visual-effects defines.