### PR TITLE
Rename `oVisualEffectsShadowsElevation` to `oVisualEffectsShadowContent`

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -8,6 +8,9 @@ The following CSS classes have been renamed:
 - `o-visual-effects-shadow--mid` is now `o-visual-effects-shadow-mid`
 - `o-visual-effects-shadow--high` is now `o-visual-effects-shadow-high`
 
+The following Sass mixin has been renamed:
+- `oVisualEffectsShadowsElevation` is now `oVisualEffectsShadowContent`.
+
 The following Sass variables have been renamed:
 - `$o-visual-effects-transition-slide` is now `$o-visual-effects-timing-slide`
 - `$o-visual-effects-transition-expand` is now `$o-visual-effects-timing-expand`

--- a/README.md
+++ b/README.md
@@ -67,13 +67,13 @@ If you are not using `o-visual-effects` CSS, and instead are using other Sass mi
 
 ### Shadows mixin
 
-The `oVisualEffectsShadowsElevation` mixin is used to add a consistent shadow to your element. There are 4 levels of shadow available: `ultralow`, `low` (default), `mid`, and `high`.
+The `oVisualEffectsShadowContent` mixin is used to add a consistent shadow to your element. There are 4 levels of shadow available: `ultralow`, `low` (default), `mid`, and `high`.
 
 Example:
 
 ```sass
 .my-element {
-	@include oVisualEffectsShadowsElevation('mid');
+	@include oVisualEffectsShadowContent('mid');
 }
 ```
 

--- a/main.scss
+++ b/main.scss
@@ -36,26 +36,26 @@
 
 	@if($ultralow) {
 		.o-visual-effects-shadow-ultralow {
-			@include oVisualEffectsShadowsElevation('ultralow');
+			@include oVisualEffectsShadowContent('ultralow');
 		}
 	}
 
 	@if($low) {
 		.o-visual-effects-shadow-low {
-			@include oVisualEffectsShadowsElevation('low');
+			@include oVisualEffectsShadowContent('low');
 		}
 	}
 
 
 	@if($mid) {
 		.o-visual-effects-shadow-mid {
-			@include oVisualEffectsShadowsElevation('mid');
+			@include oVisualEffectsShadowContent('mid');
 		}
 	}
 
 	@if($high) {
 		.o-visual-effects-shadow-high {
-			@include oVisualEffectsShadowsElevation('high');
+			@include oVisualEffectsShadowContent('high');
 		}
 	}
 }

--- a/src/scss/_shadows.scss
+++ b/src/scss/_shadows.scss
@@ -2,7 +2,7 @@
 /// @param {String} $elevation - 'ultra', 'low', 'mid' or 'high'
 /// @param {Color} $color
 /// @output A repeating linear gradient background
-@mixin oVisualEffectsShadowsElevation($elevation: 'low', $color: oColorsGetColorFor('o-effects-shadows-elevation')) {
+@mixin oVisualEffectsShadowContent($elevation: 'low', $color: oColorsGetColorFor('o-effects-shadows-elevation')) {
 	@if $elevation == 'ultralow' {
 		box-shadow: 0 2px 2px rgba($color, 0.12), 0 4px 6px rgba($color, 0.1);
 	}

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -1,8 +1,3 @@
-////
-/// @group o-visual-effects transitions
-/// @link http://registry.origami.ft.com/components/o-visual-effects
-////
-
 $o-visual-effects-silent: true !default;
 
 /// Timing function for elements that slide in and out


### PR DESCRIPTION
This indicates the mixin outputs no top level CSS selector.

See https://github.com/Financial-Times/origami-proposals/issues/14#issuecomment-485815788