### PR TITLE
Upgrade o-colors.

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -16,6 +16,8 @@ The following Sass variables have been renamed:
 - `$o-visual-effects-transition-expand` is now `$o-visual-effects-timing-expand`
 - `$o-visual-effects-transition-fade` is now `$o-visual-effects-timing-fade`
 
+The Sass o-colors usecase `o-effects-shadows-elevation` has been replaced with the Sass variable `$o-visual-effects-shadow-color`.
+
 ### Migrating from v1 to v2
 
 The following changes have been made to the mixins in o-visual-effects:

--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,6 @@
     "demo"
   ],
   "dependencies": {
-    "o-colors": "#breaking"
+    "o-colors": "5.0.0-beta.2.1.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,6 @@
     "demo"
   ],
   "dependencies": {
-    "o-colors": "^4.0.1"
+    "o-colors": "#breaking"
   }
 }

--- a/main.scss
+++ b/main.scss
@@ -1,6 +1,5 @@
 @import 'o-colors/main';
 
-@import 'src/scss/colors';
 @import 'src/scss/shadows';
 @import 'src/scss/variables';
 

--- a/src/scss/_colors.scss
+++ b/src/scss/_colors.scss
@@ -1,1 +1,0 @@
-@include oColorsSetUseCase('o-effects-shadows-elevation', 'all', 'black-70');

--- a/src/scss/_shadows.scss
+++ b/src/scss/_shadows.scss
@@ -2,7 +2,7 @@
 /// @param {String} $elevation - 'ultra', 'low', 'mid' or 'high'
 /// @param {Color} $color
 /// @output A repeating linear gradient background
-@mixin oVisualEffectsShadowContent($elevation: 'low', $color: oColorsGetColorFor('o-effects-shadows-elevation')) {
+@mixin oVisualEffectsShadowContent($elevation: 'low', $color: $o-visual-effects-shadow-color) {
 	@if $elevation == 'ultralow' {
 		box-shadow: 0 2px 2px rgba($color, 0.12), 0 4px 6px rgba($color, 0.1);
 	}

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -8,3 +8,8 @@ $o-visual-effects-timing-expand: cubic-bezier(0.215, 0.61, 0.355, 1) !default;
 
 /// Timing function for elements that fade in and out
 $o-visual-effects-timing-fade: cubic-bezier(0.165, 0.84, 0.44, 1) !default;
+
+/// The base dropdown shadow colour.
+/// Used with opacity for shadows of different levels.
+/// @type Color
+$o-visual-effects-shadow-color: oColorsByName('black-70');


### PR DESCRIPTION
Uses the breaking branch untill a stable o-colors beta is released.

Replaces a colour usecase with a Sass variable, as the colour is
not intented to be applied to a CSS property directly like other
colour usecases.